### PR TITLE
added -i flag for displaying new solutions as soon as they are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The CMD-program provides the following options:
 
 * `-c` (default OFF): Compress solutions to AXHT. This is especially useful when solving in AXQT as properly merging move sequences like `D (U D)` is not entirely trivial without having all the proper move definitions at the ready.
 
+* `-i` (default OFF): Immediately display new solutions as they are found, instead of displaying them after the timeout.
+                      If the `-m` parameter is provided, the search stops after the timeout, otherwise the search runs 
+                      forever and can be aborted by pressing CTRL-C.
+
 * `-l` (default -1): Maximum solutions length. The search will stop once a solution of at most this length is found. With `-1` the solver will simply search for the full time-limit and eventually return the best solution found.
 
 * `-m` (default 10): Time-limit in milliseconds.

--- a/src/solve.cpp
+++ b/src/solve.cpp
@@ -1,6 +1,7 @@
 #include "solve.h"
 
 #include <algorithm>
+#include <iostream>
 #include <strings.h>
 #include <thread>
 #include "prun.h"
@@ -179,8 +180,13 @@ namespace solve {
 
   Engine::Engine(
     int n_threads, int tlim,
-    int n_sols, int max_len, int n_splits
-  ) : n_threads(n_threads), tlim(tlim), n_sols(n_sols), max_len(max_len), n_splits(n_splits) {
+    int n_sols, int max_len, int n_splits,
+    bool display_solutions_immediately,
+    bool compress
+  ) : n_threads(n_threads), tlim(tlim), 
+      n_sols(n_sols), max_len(max_len), n_splits(n_splits),
+      display_solutions_immediately(display_solutions_immediately),
+      compress(compress) {
     int tmp = (move::COUNT1 + n_splits - 1) / n_splits; // ceil to make sure that we always include all moves
     for (int i = 0; i < n_splits; i++)
       masks[i] = (move::mask(1) << tmp) - 1 << tmp * i;
@@ -252,7 +258,10 @@ namespace solve {
 
     { // timeout
       std::unique_lock<std::mutex> lock(tout_mtx);
-      tout_cvar.wait_for(lock, std::chrono::milliseconds(tlim), [&]{ return done; });
+      if (tlim == -1)
+        tout_cvar.wait(lock, [&] { return done; });
+      else
+        tout_cvar.wait_for(lock, std::chrono::milliseconds(tlim), [&] { return done; });
       if (!done)
         done = true; // if we get here, this was a timeout
     }
@@ -283,10 +292,16 @@ namespace solve {
     if (done) // prevent any type of reporting after the solver has terminated (important for threading)
       return;
 
+    bool print_sol = false;
+
     sols.push(sol); // usually we only get here if we actually have a solution that will be added
     if (sols.size() > n_sols)
+    {
+      print_sol = sols.top() != sol;  // only print solution if is was actually added
       sols.pop();
+    }
     if (sols.size() == n_sols) {
+      print_sol = true;
       lenlim = sols.top().first.size(); // only search for strictly shorter solutions
 
       if (lenlim <= max_len) { // already found a solution that is short enough
@@ -296,6 +311,39 @@ namespace solve {
         tout_cvar.notify_one();
       }
     }
+
+    if (print_sol && display_solutions_immediately)
+    {
+      std::vector<int> res;
+      res.resize(sols.size());
+      res.resize(sol.first.size());
+
+      int rot = sym::ROT * (sol.second / 2);
+      for (int j = 0; j < res.size(); j++) // undo rotation
+        res[j] = sym::conj_move[sol.first[j]][rot];
+
+      if (sol.second & 1)
+      { // undo inversion
+        for (int j = 0; j < res.size(); j++)
+          res[j] = move::inv[res[j]];
+        std::reverse(res.begin(), res.end());
+      }
+      std::cout << "New solution found: ";
+      if (compress)
+        std::cout << move::compress(res) << " ";
+      else
+        for (int m : res)
+          std::cout << move::names[m] << " ";
+      std::cout << "(" << sol.first.size() << ")" << std::endl;
+    }
+  }
+
+  void Engine::abort()
+  {
+    std::cout << "Aborting active solve" << std::endl;
+    done = true;
+    std::lock_guard<std::mutex> lock(tout_mtx);
+    tout_cvar.notify_one();
   }
 
   void Engine::finish() {

--- a/src/solve.h
+++ b/src/solve.h
@@ -38,6 +38,9 @@ namespace solve {
     int max_len; // find solutions with at most this length; -1 means simply search for the full `tlimit`
     int tlim; // search for this amount of milliseconds
 
+    bool display_solutions_immediately;  // if true, print solutions as the are found, -i flag
+    bool compress;                       // as in main.cpp (use for -i flag)
+
     coordc dirs[N_DIRS]; // search directions
     move::mask masks[move::COUNT1]; // split masks
     int depths[N_DIRS]; // current search depths per direction
@@ -57,12 +60,15 @@ namespace solve {
     public:
       Engine(
         int n_threads, int tlim,
-        int n_sols = 1, int max_len = -1, int n_splits = 1
+        int n_sols = 1, int max_len = -1, int n_splits = 1,
+        bool display_solutions_immediately = false,
+        bool compress = false
       );
       void prepare(); // setup all threads
       void solve(const cubie::cube& c, std::vector<std::vector<int>>& res); // actual solve
       void finish(); // wait for all threads to shutdown (mostly for clean program exit)
       void report_sol(searchres& sol); // report a solution; never call this from the outside
+      void abort(); // stop a correctly running solve
 
     void thread(); // search thread
 


### PR DESCRIPTION
I added and implemented the flag -i. The changes are backwards compatible. 
If the flag is provided new solutions are printed immediately instead of after the timeout. By default the search with -i runs for ever and is stopped by pressing CTRL-C. If a timeout is provided with -m, the search stops after the timeout. 