### PR TITLE
pthread changes in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 C=gcc
 CXX=g++
 RM=rm -f
-CPPFLAGS=-std=c++11 -lpthread -O3
+CPPFLAGS=-std=c++11 -O3
 LDFLAGS=
 LDLIBS=-lpthread
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CXX=g++
 RM=rm -f
 CPPFLAGS=-std=c++11 -O3
 LDFLAGS=
-LDLIBS=-lpthread
+LDLIBS=-pthread
 
 SRCS=$(patsubst %,src/%,main.cpp coord.cpp cubie.cpp face.cpp move.cpp prun.cpp solve.cpp sym.cpp)
 OBJS=$(subst .cpp,.o,$(SRCS))


### PR DESCRIPTION
-lpthread in the CPPFLAGS is unnecessary. It is linked with the LDLIBS.