### PR TITLE
Uninitialized variables

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 C=gcc
 CXX=g++
 RM=rm -f
-CPPFLAGS=-std=c++11 -lpthread -O3
+CPPFLAGS=-std=c++11 -O3
 LDFLAGS=
 LDLIBS=-lpthread
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CXX=g++
 RM=rm -f
 CPPFLAGS=-std=c++11 -O3
 LDFLAGS=
-LDLIBS=-lpthread
+LDLIBS=-pthread
 
 SRCS=$(patsubst %,src/%,main.cpp coord.cpp cubie.cpp face.cpp move.cpp prun.cpp solve.cpp sym.cpp)
 OBJS=$(subst .cpp,.o,$(SRCS))

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -89,8 +89,8 @@ namespace move {
 
     cubie::cube cubes1[45];
     int inv1[45];
-    mask next1[45];
-    mask qt_skip1[45];
+    mask next1[45] = {0};
+    mask qt_skip1[45] = {0};
 
     std::string fnames[] = {"U", "D", "R", "L", "F", "B"};
     std::string pnames[] = {"", "2", "'"};

--- a/src/prun.cpp
+++ b/src/prun.cpp
@@ -5,8 +5,20 @@
 #include <cstring>
 
 namespace prun {
+  const std::string SAVE = "twophase"
+  #ifdef QT
+    "_QT"
+  #else
+    "_HT"
+  #endif
+  #ifdef AX
+    "_AX"
+  #endif
+  #ifdef F5
+    "_F5"
+  #endif
+  ".tbl";
 
-  const std::string SAVE = "twophase.tbl";
   const int EMPTY = 0xff;
 
   #ifdef AX


### PR DESCRIPTION
There were two uninitialized arrays of masks from which uninitialized values were read from. I've initialized these with 0 because it seems reasonable.
With this change, the solver produces the same output on macOS as on Ubuntu and it is just as fast :)